### PR TITLE
fix(MAP-235): fix android backspace bug

### DIFF
--- a/packages/lexical/src/LexicalEvents.ts
+++ b/packages/lexical/src/LexicalEvents.ts
@@ -515,6 +515,12 @@ function onBeforeInput(event: InputEvent, editor: LexicalEditor): void {
 
       if ($isRangeSelection(selection)) {
         // Used for handling backspace in Android.
+        const isAndroidDevice = !!navigator.userAgent.match(/Android/i);
+
+        if (isAndroidDevice) {
+          $setCompositionKey(selection.anchor.key);
+        }
+
         if (
           isPossiblyAndroidKeyPress(event.timeStamp) &&
           editor.isComposing() &&


### PR DESCRIPTION
**Context:**

When this [line](https://github.com/facebook/lexical/blob/main/packages/lexical/src/LexicalEvents.ts#L520) `editor.isComposing()` is evaluated, the value returned is always `false`, so the code within the `if` is not executed and continues to the `else`.

This causes deleting a character on an Android device to delete the character on the right.

I was testing a bit and giving a value to the `_compositionKey` property fixes it.

**Jira task:** [MAP-235](https://taringa.atlassian.net/browse/MAP-235)
**Jira subtask:** [MAP-314](https://taringa.atlassian.net/browse/MAP-314)

**Evidence:** https://www.loom.com/share/24898783cffd4023bf85460966702898

[MAP-235]: https://taringa.atlassian.net/browse/MAP-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAP-314]: https://taringa.atlassian.net/browse/MAP-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ